### PR TITLE
Prettify response explorer

### DIFF
--- a/rest/playground/templates/base.html
+++ b/rest/playground/templates/base.html
@@ -15,6 +15,8 @@
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+
+    <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.4.1/src-noconflict/ace.js"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/rest/playground/templates/home.html
+++ b/rest/playground/templates/home.html
@@ -5,6 +5,13 @@ LD Server Playground
 {% endblock %}
 
 {% block content %}
+<style>
+#json-response {
+  height:200px;
+  width:100%;
+}
+</style>
+
 <nav class="navbar sticky-top navbar-dark bg-primary mb-2">
     <span class="navbar-brand mb-0 h1">LD Server Playground</span>
 </nav>
@@ -117,15 +124,9 @@ LD Server Playground
                                 <textarea class="form-control" row="2" id="input-http-request" readonly></textarea>
                             </div>
                         </div>
-                        <div class="form-group">
-                            <label for="json-response">JSON Response</label>
-                            <div class="input-group">
-                                <!--<pre class="pre-scrollable" id="json-response">-->
-                                    <!--<code></code>-->
-                                <!--</pre>-->
-                                <textarea class="form-control" rows="5" id="json-response" readonly></textarea>
-                            </div>
-                        </div>
+                        <div class="text-danger" id="status-message"></div>
+                        <label for="json-response">JSON Response</label>
+                        <div id="json-response"></div>
                     </form>
                 </div>
             </div>
@@ -137,6 +138,12 @@ LD Server Playground
 
 {% block scripts %}
 <script>
+    // Configure ACE editor (for exploring JSON)
+    var editor = ace.edit("json-response", {
+        readOnly: true,
+        mode: "ace/mode/javascript",
+    });
+
     var restAPI = "http://127.0.0.1:5000";
     var queryType = 1;
 
@@ -250,9 +257,7 @@ LD Server Playground
             dataType: "json",
             async: false,
             success: function (result) {
-                console.log(result);
                 $.each(result, function (i, correlation) {
-                    console.log(correlation);
                     $("#select-correlation").append(
                         $('<option>', {value: correlation.name, text: correlation.label})
                     );
@@ -337,15 +342,18 @@ LD Server Playground
 
     function run() {
         var request = $("#input-http-request")[0].value;
-
+        var statusdiv = $('#status-message');
+        editor.setValue("");
+        statusdiv.text("");
         $.ajax({
             url: request,
             type: "GET",
             crossDomain: true,
-            dataType: "json",
-            success: function(result) {
-                $("#json-response")[0].value = JSON.stringify(result, null, 3);
-            }
+        }).done(function(result) {
+            editor.setValue(JSON.stringify(result, null, 4));
+        }).fail(function(xhr, status, err) {
+            console.error(err);
+            statusdiv.text(err ? (err.message || err) : "An error occurred")
         });
     }
 


### PR DESCRIPTION
# Purpose
Make the API playground feature a bit more user friendly. This is completely optional- feel free to use some, all, or none of these changes.

- Show an error message when a request fails, and clear the previous results. Previously, errors were failing silently. 
- Use ACE editor to render the JSON response, which enables expanding/ collapsing long array keys

<img width="1430" alt="screen shot 2018-10-11 at 11 28 29 am" src="https://user-images.githubusercontent.com/2957073/46815901-d682c080-cd49-11e8-9415-acc058d4a11a.png">
<img width="970" alt="screen shot 2018-10-11 at 11 28 44 am" src="https://user-images.githubusercontent.com/2957073/46815902-d682c080-cd49-11e8-8c32-8d0f572ccdd1.png">


## Notes
The screenshot above specifies a region with 10k variants (the max per page), useful for testing the fancy display widget in a worse case scenario. 

No performance issues encountered (using Chrome and FF), but test was conducted using a 16GB RAM MBP.